### PR TITLE
Replaced ManiaMapManger singleton with LayoutPack class instances

### DIFF
--- a/addons/mpewsey.maniamap/scripts/runtime/IDoorNodeExtensions.cs
+++ b/addons/mpewsey.maniamap/scripts/runtime/IDoorNodeExtensions.cs
@@ -23,10 +23,11 @@ namespace MPewsey.ManiaMapGodot
         public static DoorConnection FindDoorConnection(this IDoorNode door)
         {
             var roomId = door.RoomNode.RoomLayout.Id;
+            var doorConnections = door.RoomNode.LayoutPack.GetDoorConnections(roomId);
             var position = new Vector2DInt(door.Row, door.Column);
             var direction = door.DoorDirection;
 
-            foreach (var connection in door.RoomNode.DoorConnections)
+            foreach (var connection in doorConnections)
             {
                 if (connection.ContainsDoor(roomId, position, direction))
                     return connection;

--- a/addons/mpewsey.maniamap/scripts/runtime/IRoomNode.cs
+++ b/addons/mpewsey.maniamap/scripts/runtime/IRoomNode.cs
@@ -1,5 +1,4 @@
 using MPewsey.ManiaMap;
-using System.Collections.Generic;
 
 namespace MPewsey.ManiaMapGodot
 {
@@ -29,14 +28,9 @@ namespace MPewsey.ManiaMapGodot
         public Godot.Collections.Array<Godot.Collections.Array<bool>> ActiveCells { get; set; }
 
         /// <summary>
-        /// The current layout.
+        /// The current layout pack.
         /// </summary>
-        public Layout Layout { get; }
-
-        /// <summary>
-        /// The current layout state.
-        /// </summary>
-        public LayoutState LayoutState { get; }
+        public LayoutPack LayoutPack { get; }
 
         /// <summary>
         /// This room's layout.
@@ -47,11 +41,6 @@ namespace MPewsey.ManiaMapGodot
         /// This room's layout state.
         /// </summary>
         public RoomState RoomState { get; }
-
-        /// <summary>
-        /// A list of door connections for the room.
-        /// </summary>
-        public IReadOnlyList<DoorConnection> DoorConnections { get; }
 
         /// <summary>
         /// True if the room has been initialized.

--- a/addons/mpewsey.maniamap/scripts/runtime/LayoutPack.cs
+++ b/addons/mpewsey.maniamap/scripts/runtime/LayoutPack.cs
@@ -8,54 +8,49 @@ namespace MPewsey.ManiaMapGodot
     /// <summary>
     /// Holds the current `Layout` and `LayoutState`.
     /// </summary>
-    public partial class ManiaMapManager : GodotObject
+    public class LayoutPack
     {
         /// <summary>
-        /// The current manager.
+        /// The layout.
         /// </summary>
-        public static ManiaMapManager Current { get; private set; }
+        public Layout Layout { get; }
 
         /// <summary>
-        /// The current layout.
+        /// The layout state.
         /// </summary>
-        public Layout Layout { get; private set; }
+        public LayoutState LayoutState { get; }
 
         /// <summary>
-        /// The current layout state.
+        /// The settings.
         /// </summary>
-        public LayoutState LayoutState { get; private set; }
-
-        /// <summary>
-        /// The current settings.
-        /// </summary>
-        public ManiaMapSettings Settings { get; private set; }
+        public ManiaMapSettings Settings { get; }
 
         /// <summary>
         /// A dictionary of door connections by room ID.
         /// </summary>
-        private Dictionary<Uid, List<DoorConnection>> RoomConnections { get; set; } = new Dictionary<Uid, List<DoorConnection>>();
+        private Dictionary<Uid, List<DoorConnection>> RoomConnections { get; } = new Dictionary<Uid, List<DoorConnection>>();
 
         /// <summary>
-        /// Initializes a new manager and sets it as the current manager.
+        /// Initializes a new layout pack.
         /// </summary>
         /// <param name="layout">The layout.</param>
         /// <param name="state">The layout state.</param>
         /// <param name="settingsPath">The path to the ManiaMapSettings resource.</param>
-        public static ManiaMapManager Initialize(Layout layout, LayoutState state, string settingsPath)
+        public LayoutPack(Layout layout, LayoutState state, string settingsPath)
+            : this(layout, state, ResourceLoader.Load<ManiaMapSettings>(settingsPath))
         {
-            var settings = ResourceLoader.Load<ManiaMapSettings>(settingsPath);
-            return Initialize(layout, state, settings);
+
         }
 
         /// <summary>
-        /// Initializes a new manager and sets it as the current manager.
+        /// Initializes a new layout pack.
         /// </summary>
         /// <param name="layout">The layout.</param>
         /// <param name="state">The layout state.</param>
         /// <param name="settings">The settings resource. If null, a new default instance of the settings will be used.</param>
         /// <exception cref="ArgumentNullException">Thrown if the layout or layout state is null.</exception>
         /// <exception cref="ArgumentException">Thrown if the layout and layout state ID's do not match.</exception>
-        public static ManiaMapManager Initialize(Layout layout, LayoutState state, ManiaMapSettings settings = null)
+        public LayoutPack(Layout layout, LayoutState state, ManiaMapSettings settings = null)
         {
             ArgumentNullException.ThrowIfNull(layout, nameof(layout));
             ArgumentNullException.ThrowIfNull(state, nameof(state));
@@ -63,24 +58,10 @@ namespace MPewsey.ManiaMapGodot
             if (layout.Id != state.Id)
                 throw new ArgumentException($"Layout and layout state ID's do not match: (Layout ID = {layout.Id}, Layout State ID = {state.Id})");
 
-            var manager = new ManiaMapManager()
-            {
-                Layout = layout,
-                LayoutState = state,
-                Settings = settings ?? new ManiaMapSettings(),
-                RoomConnections = layout.GetRoomConnections(),
-            };
-
-            manager.SetAsCurrent();
-            return manager;
-        }
-
-        /// <summary>
-        /// Assigns the manager to the current manager static property.
-        /// </summary>
-        private void SetAsCurrent()
-        {
-            Current = this;
+            Layout = layout;
+            LayoutState = state;
+            Settings = settings;
+            RoomConnections = layout.GetRoomConnections();
         }
 
         /// <summary>

--- a/addons/mpewsey.maniamap/scripts/runtime/RoomNode2D.cs
+++ b/addons/mpewsey.maniamap/scripts/runtime/RoomNode2D.cs
@@ -2,7 +2,6 @@ using Godot;
 using MPewsey.ManiaMap;
 using MPewsey.ManiaMapGodot.Exceptions;
 using System;
-using System.Collections.Generic;
 
 namespace MPewsey.ManiaMapGodot
 {
@@ -59,19 +58,13 @@ namespace MPewsey.ManiaMapGodot
         [Export] public Godot.Collections.Array<Godot.Collections.Array<bool>> ActiveCells { get; set; } = new Godot.Collections.Array<Godot.Collections.Array<bool>>();
 
         /// <inheritdoc/>
-        public Layout Layout { get; private set; }
-
-        /// <inheritdoc/>
-        public LayoutState LayoutState { get; private set; }
+        public LayoutPack LayoutPack { get; private set; }
 
         /// <inheritdoc/>
         public Room RoomLayout { get; private set; }
 
         /// <inheritdoc/>
         public RoomState RoomState { get; private set; }
-
-        /// <inheritdoc/>
-        public IReadOnlyList<DoorConnection> DoorConnections { get; private set; } = Array.Empty<DoorConnection>();
 
         /// <inheritdoc/>
         public bool IsInitialized { get; private set; }
@@ -182,19 +175,16 @@ namespace MPewsey.ManiaMapGodot
         /// The layout and layout state are assigned to the room based on the current ManiaMapManager.
         /// </summary>
         /// <param name="id">The room ID.</param>
+        /// <param name="layoutPack">The layout pack.</param>
         /// <param name="scene">The room scene.</param>
         /// <param name="parent">The node to which the room will be added as a child.</param>
         /// <param name="assignLayoutPosition">If true, the position of the room will be set to that of the room layout. Otherwise, it will be initialized at its original position.</param>
-        public static RoomNode2D CreateInstance(Uid id, PackedScene scene, Node parent, bool assignLayoutPosition = false)
+        public static RoomNode2D CreateInstance(Uid id, LayoutPack layoutPack, PackedScene scene, Node parent, bool assignLayoutPosition = false)
         {
-            var manager = ManiaMapManager.Current;
-            var layout = manager.Layout;
-            var layoutState = manager.LayoutState;
-            var roomLayout = layout.Rooms[id];
-            var roomState = layoutState.RoomStates[id];
-            var doorConnections = manager.GetDoorConnections(id);
-            var collisionMask = manager.Settings.CellCollisionMask;
-            return CreateInstance(scene, parent, layout, layoutState, roomLayout, roomState, doorConnections, collisionMask, assignLayoutPosition);
+            var roomLayout = layoutPack.Layout.Rooms[id];
+            var roomState = layoutPack.LayoutState.RoomStates[id];
+            var collisionMask = layoutPack.Settings.CellCollisionMask;
+            return CreateInstance(scene, parent, layoutPack, roomLayout, roomState, collisionMask, assignLayoutPosition);
         }
 
         /// <summary>
@@ -202,19 +192,16 @@ namespace MPewsey.ManiaMapGodot
         /// </summary>
         /// <param name="scene">The room scene.</param>
         /// <param name="parent">The node to which the room will be added as a child.</param>
-        /// <param name="layout">The full layout.</param>
-        /// <param name="layoutState">The full layout state.</param>
+        /// <param name="layoutPack">The layout pack..</param>
         /// <param name="roomLayout">The room's layout.</param>
         /// <param name="roomState">The room's state.</param>
-        /// <param name="doorConnections">The room's door connections.</param>
         /// <param name="cellCollisionMask">The cell collision mask.</param>
         /// <param name="assignLayoutPosition">If true, the position of the room will be set to that of the room layout. Otherwise, it will be initialized at its original position.</param>
-        public static RoomNode2D CreateInstance(PackedScene scene, Node parent, Layout layout, LayoutState layoutState,
-            Room roomLayout, RoomState roomState, IReadOnlyList<DoorConnection> doorConnections,
-            uint cellCollisionMask, bool assignLayoutPosition)
+        public static RoomNode2D CreateInstance(PackedScene scene, Node parent, LayoutPack layoutPack,
+            Room roomLayout, RoomState roomState, uint cellCollisionMask, bool assignLayoutPosition)
         {
             var room = scene.Instantiate<RoomNode2D>();
-            room.Initialize(layout, layoutState, roomLayout, roomState, doorConnections, cellCollisionMask, assignLayoutPosition);
+            room.Initialize(layoutPack, roomLayout, roomState, cellCollisionMask, assignLayoutPosition);
             parent.AddChild(room);
             return room;
         }
@@ -226,24 +213,20 @@ namespace MPewsey.ManiaMapGodot
         /// If the room has already been initialized, no action is taken, and this method returns false.
         /// Othwerwise, it returns true.
         /// </summary>
-        /// <param name="layout">The full layout.</param>
-        /// <param name="layoutState">The full layout state.</param>
+        /// <param name="layoutPack">The layout pack.</param>
         /// <param name="roomLayout">The room's layout.</param>
         /// <param name="roomState">The room's state.</param>
-        /// <param name="doorConnections">The room's door connections.</param>
         /// <param name="cellCollisionMask">The cell collision mask.</param>
         /// <param name="assignLayoutPosition">If true, the position of the room will be set to that of the room layout. Otherwise, it will be initialized at its original position.</param>
-        public bool Initialize(Layout layout, LayoutState layoutState, Room roomLayout, RoomState roomState,
-            IReadOnlyList<DoorConnection> doorConnections, uint cellCollisionMask, bool assignLayoutPosition)
+        public bool Initialize(LayoutPack layoutPack, Room roomLayout, RoomState roomState,
+            uint cellCollisionMask, bool assignLayoutPosition)
         {
             if (IsInitialized)
                 return false;
 
-            Layout = layout;
-            LayoutState = layoutState;
+            LayoutPack = layoutPack;
             RoomLayout = roomLayout;
             RoomState = roomState;
-            DoorConnections = doorConnections;
 
             if (assignLayoutPosition)
                 MoveToLayoutPosition();

--- a/addons/mpewsey.maniamap/scripts/runtime/RoomTemplateDatabase.cs
+++ b/addons/mpewsey.maniamap/scripts/runtime/RoomTemplateDatabase.cs
@@ -99,10 +99,9 @@ namespace MPewsey.ManiaMapGodot
         /// This method uses the layout from the current ManiaMapManager.
         /// </summary>
         /// <param name="id">The room ID.</param>
-        public RoomTemplateResource GetRoomTemplate(Uid id)
+        public RoomTemplateResource GetRoomTemplate(Uid id, LayoutPack layoutPack)
         {
-            var manager = ManiaMapManager.Current;
-            var room = manager.Layout.Rooms[id];
+            var room = layoutPack.Layout.Rooms[id];
             return GetRoomTemplate(room.Template.Id);
         }
 
@@ -139,18 +138,17 @@ namespace MPewsey.ManiaMapGodot
         /// </summary>
         /// <param name="parent">The node serving as the parent of the rooms.</param>
         /// <param name="z">The layer coordinate to instantiate.</param>
-        public async Task<List<RoomNode2D>> CreateRoom2DInstancesAsync(Node parent, int? z = null, bool useSubThreads = false)
+        public async Task<List<RoomNode2D>> CreateRoom2DInstancesAsync(Node parent, LayoutPack layoutPack, int? z = null, bool useSubThreads = false)
         {
-            var manager = ManiaMapManager.Current;
-            z ??= manager.Layout.Rooms.Values.Select(x => x.Position.Z).First();
-            var rooms = manager.Layout.Rooms.Values.Where(x => x.Position.Z == z).ToList();
+            z ??= layoutPack.Layout.Rooms.Values.Select(x => x.Position.Z).First();
+            var rooms = layoutPack.Layout.Rooms.Values.Where(x => x.Position.Z == z).ToList();
             var scenes = await LoadScenesAsync(rooms, useSubThreads);
             var result = new List<RoomNode2D>(rooms.Count);
 
             foreach (var room in rooms)
             {
                 var scene = scenes[room.Template.Id];
-                result.Add(RoomNode2D.CreateInstance(room.Id, scene, parent, true));
+                result.Add(RoomNode2D.CreateInstance(room.Id, layoutPack, scene, parent, true));
             }
 
             return result;
@@ -161,17 +159,16 @@ namespace MPewsey.ManiaMapGodot
         /// Returns a list of the instantiated rooms.
         /// </summary>
         /// <param name="parent">The node serving as the parent of the rooms.</param>
-        public async Task<List<RoomNode3D>> CreateRoom3DInstancesAsync(Node parent, bool useSubThreads = false)
+        public async Task<List<RoomNode3D>> CreateRoom3DInstancesAsync(Node parent, LayoutPack layoutPack, bool useSubThreads = false)
         {
-            var manager = ManiaMapManager.Current;
-            var rooms = manager.Layout.Rooms.Values.ToList();
+            var rooms = layoutPack.Layout.Rooms.Values.ToList();
             var scenes = await LoadScenesAsync(rooms, useSubThreads);
             var result = new List<RoomNode3D>(rooms.Count);
 
             foreach (var room in rooms)
             {
                 var scene = scenes[room.Template.Id];
-                result.Add(RoomNode3D.CreateInstance(room.Id, scene, parent, true));
+                result.Add(RoomNode3D.CreateInstance(room.Id, layoutPack, scene, parent, true));
             }
 
             return result;
@@ -183,18 +180,17 @@ namespace MPewsey.ManiaMapGodot
         /// </summary>
         /// <param name="parent">The node serving as the parent of the rooms.</param>
         /// <param name="z">The layer coordinate to instantiate.</param>
-        public List<RoomNode2D> CreateRoom2DInstances(Node parent, int? z = null)
+        public List<RoomNode2D> CreateRoom2DInstances(Node parent, LayoutPack layoutPack, int? z = null)
         {
-            var manager = ManiaMapManager.Current;
-            z ??= manager.Layout.Rooms.Values.Select(x => x.Position.Z).First();
+            z ??= layoutPack.Layout.Rooms.Values.Select(x => x.Position.Z).First();
             var result = new List<RoomNode2D>();
 
-            foreach (var room in manager.Layout.Rooms.Values)
+            foreach (var room in layoutPack.Layout.Rooms.Values)
             {
                 if (room.Position.Z == z)
                 {
                     var template = GetRoomTemplate(room.Template.Id);
-                    result.Add(RoomNode2D.CreateInstance(room.Id, template.LoadScene(), parent, true));
+                    result.Add(RoomNode2D.CreateInstance(room.Id, layoutPack, template.LoadScene(), parent, true));
                 }
             }
 
@@ -206,15 +202,14 @@ namespace MPewsey.ManiaMapGodot
         /// Returns a list of the instantiated rooms.
         /// </summary>
         /// <param name="parent">The node serving as the parent of the rooms.</param>
-        public List<RoomNode3D> CreateRoom3DInstances(Node parent)
+        public List<RoomNode3D> CreateRoom3DInstances(Node parent, LayoutPack layoutPack)
         {
-            var manager = ManiaMapManager.Current;
             var result = new List<RoomNode3D>();
 
-            foreach (var room in manager.Layout.Rooms.Values)
+            foreach (var room in layoutPack.Layout.Rooms.Values)
             {
                 var template = GetRoomTemplate(room.Template.Id);
-                result.Add(RoomNode3D.CreateInstance(room.Id, template.LoadScene(), parent, true));
+                result.Add(RoomNode3D.CreateInstance(room.Id, layoutPack, template.LoadScene(), parent, true));
             }
 
             return result;
@@ -227,10 +222,10 @@ namespace MPewsey.ManiaMapGodot
         /// <param name="id">The room ID.</param>
         /// <param name="parent">The node serving as the room's parent.</param>
         /// <param name="assignLayoutPosition">If true, the layout position will be assigned to the room.</param>
-        public async Task<RoomNode2D> CreateRoom2DInstanceAsync(Uid id, Node parent, bool assignLayoutPosition = false, bool useSubThreads = false)
+        public async Task<RoomNode2D> CreateRoom2DInstanceAsync(Uid id, LayoutPack layoutPack, Node parent, bool assignLayoutPosition = false, bool useSubThreads = false)
         {
-            var scene = await GetRoomTemplate(id).LoadSceneAsync(useSubThreads);
-            return RoomNode2D.CreateInstance(id, scene, parent, assignLayoutPosition);
+            var scene = await GetRoomTemplate(id, layoutPack).LoadSceneAsync(useSubThreads);
+            return RoomNode2D.CreateInstance(id, layoutPack, scene, parent, assignLayoutPosition);
         }
 
         /// <summary>
@@ -240,10 +235,10 @@ namespace MPewsey.ManiaMapGodot
         /// <param name="id">The room ID.</param>
         /// <param name="parent">The node serving as the room's parent.</param>
         /// <param name="assignLayoutPosition">If true, the layout position will be assigned to the room.</param>
-        public async Task<RoomNode3D> CreateRoom3DInstanceAsync(Uid id, Node parent, bool assignLayoutPosition = false, bool useSubThreads = false)
+        public async Task<RoomNode3D> CreateRoom3DInstanceAsync(Uid id, LayoutPack layoutPack, Node parent, bool assignLayoutPosition = false, bool useSubThreads = false)
         {
-            var scene = await GetRoomTemplate(id).LoadSceneAsync(useSubThreads);
-            return RoomNode3D.CreateInstance(id, scene, parent, assignLayoutPosition);
+            var scene = await GetRoomTemplate(id, layoutPack).LoadSceneAsync(useSubThreads);
+            return RoomNode3D.CreateInstance(id, layoutPack, scene, parent, assignLayoutPosition);
         }
 
         /// <summary>
@@ -253,9 +248,10 @@ namespace MPewsey.ManiaMapGodot
         /// <param name="id">The room ID.</param>
         /// <param name="parent">The node serving as the room's parent.</param>
         /// <param name="assignLayoutPosition">If true, the layout position will be assigned to the room.</param>
-        public RoomNode2D CreateRoom2DInstance(Uid id, Node parent, bool assignLayoutPosition = false)
+        public RoomNode2D CreateRoom2DInstance(Uid id, LayoutPack layoutPack, Node parent, bool assignLayoutPosition = false)
         {
-            return RoomNode2D.CreateInstance(id, GetRoomTemplate(id).LoadScene(), parent, assignLayoutPosition);
+            var scene = GetRoomTemplate(id, layoutPack).LoadScene();
+            return RoomNode2D.CreateInstance(id, layoutPack, scene, parent, assignLayoutPosition);
         }
 
         /// <summary>
@@ -265,9 +261,10 @@ namespace MPewsey.ManiaMapGodot
         /// <param name="id">The room ID.</param>
         /// <param name="parent">The node serving as the room's parent.</param>
         /// <param name="assignLayoutPosition">If true, the layout position will be assigned to the room.</param>
-        public RoomNode3D CreateRoom3DInstance(Uid id, Node parent, bool assignLayoutPosition = false)
+        public RoomNode3D CreateRoom3DInstance(Uid id, LayoutPack layoutPack, Node parent, bool assignLayoutPosition = false)
         {
-            return RoomNode3D.CreateInstance(id, GetRoomTemplate(id).LoadScene(), parent, assignLayoutPosition);
+            var scene = GetRoomTemplate(id, layoutPack).LoadScene();
+            return RoomNode3D.CreateInstance(id, layoutPack, scene, parent, assignLayoutPosition);
         }
     }
 }

--- a/addons/mpewsey.maniamap/scripts/runtime/drawing/LayoutTileMap.cs
+++ b/addons/mpewsey.maniamap/scripts/runtime/drawing/LayoutTileMap.cs
@@ -28,13 +28,13 @@ namespace MPewsey.ManiaMapGodot.Drawing
         }
 
         /// <summary>
-        /// Draws the map for the specified layer (z) coordinate based on the current ManiaMapManager layout.
+        /// Draws the map for the specified layer (z) coordinate.
         /// </summary>
+        /// <param name="layoutPack">The layout pack.</param>
         /// <param name="z">The layer coordinate. If null, the minimum layer coordinate in the layout will be used.</param>
-        public void DrawMap(int? z = null)
+        public void DrawMap(LayoutPack layoutPack, int? z = null)
         {
-            var manager = ManiaMapManager.Current;
-            DrawMap(manager.Layout, manager.LayoutState, z);
+            DrawMap(layoutPack.Layout, layoutPack.LayoutState, z);
         }
 
         /// <summary>

--- a/addons/mpewsey.maniamap/scripts/runtime/drawing/LayoutTileMapBook.cs
+++ b/addons/mpewsey.maniamap/scripts/runtime/drawing/LayoutTileMapBook.cs
@@ -41,17 +41,19 @@ namespace MPewsey.ManiaMapGodot.Drawing
         }
 
         /// <summary>
-        /// Draws all layout layers onto tile maps using the ManiaMapManager layout.
+        /// Draws all layout layers onto tile maps.
         /// </summary>
-        public void DrawPages()
+        /// <param name="layoutPack">The layout pack.</param>
+        public void DrawPages(LayoutPack layoutPack)
         {
-            var manager = ManiaMapManager.Current;
-            DrawPages(manager.Layout, manager.LayoutState);
+            DrawPages(layoutPack.Layout, layoutPack.LayoutState);
         }
 
         /// <summary>
         /// Draws all layout layers onto tile maps.
         /// </summary>
+        /// <param name="layout">The layout.</param>
+        /// <param name="layoutState">The layout state. If null, the full map will be drawn. Otherwise, the layout state cell visibilities will be applied.</param>
         public void DrawPages(Layout layout, LayoutState layoutState = null)
         {
             Initialize(layout, layoutState);

--- a/samples/scripts/RoomLayout2DSample.cs
+++ b/samples/scripts/RoomLayout2DSample.cs
@@ -53,9 +53,9 @@ namespace MPewsey.ManiaMapGodot.Samples
 
             MessageLabel.Text = string.Empty;
             var layout = results.GetOutput<Layout>("Layout");
-            ManiaMapManager.Initialize(layout, new LayoutState(layout), new ManiaMapSettings());
+            var layoutPack = new LayoutPack(layout, new LayoutState(layout), new ManiaMapSettings());
             ClearContainer();
-            RoomTemplateDatabase.CreateRoom2DInstances(Container);
+            RoomTemplateDatabase.CreateRoom2DInstances(Container, layoutPack);
             Camera.CenterCameraView(layout, CellSize);
         }
     }

--- a/samples/scripts/RoomLayout3DSample.cs
+++ b/samples/scripts/RoomLayout3DSample.cs
@@ -53,9 +53,9 @@ namespace MPewsey.ManiaMapGodot.Samples
 
             MessageLabel.Text = string.Empty;
             var layout = results.GetOutput<Layout>("Layout");
-            ManiaMapManager.Initialize(layout, new LayoutState(layout), new ManiaMapSettings());
+            var layoutPack = new LayoutPack(layout, new LayoutState(layout), new ManiaMapSettings());
             ClearContainer();
-            RoomTemplateDatabase.CreateRoom3DInstances(Container);
+            RoomTemplateDatabase.CreateRoom3DInstances(Container, layoutPack);
             Camera.ResetPosition();
         }
     }

--- a/tests/scripts/TestRoomNode2D.cs
+++ b/tests/scripts/TestRoomNode2D.cs
@@ -142,9 +142,9 @@ namespace MPewsey.ManiaMapGodot.Tests
             var state = new LayoutState(layout);
             var roomId = layout.Rooms.Keys.First();
             var roomState = state.RoomStates[roomId];
-            ManiaMapManager.Initialize(layout, state, new ManiaMapSettings());
+            var layoutPack = new LayoutPack(layout, state, new ManiaMapSettings());
 
-            var room = database.CreateRoom2DInstance(roomId, root);
+            var room = database.CreateRoom2DInstance(roomId, layoutPack, root);
             var roomFlags = room.FindChildren("*", nameof(RoomFlag2D), true, false);
             Assertions.AssertThat(roomFlags.Count).IsGreater(0);
             var roomFlag = roomFlags[0] as RoomFlag2D;
@@ -189,11 +189,11 @@ namespace MPewsey.ManiaMapGodot.Tests
             var state = new LayoutState(layout);
             var roomId = layout.Rooms.Keys.First();
             var roomState = state.RoomStates[roomId];
-            ManiaMapManager.Initialize(layout, state, settings);
+            var layoutPack = new LayoutPack(layout, state, settings);
 
             // Create room and hook up signals to detect the cells the test area is touching.
             var database = ResourceLoader.Load<RoomTemplateDatabase>(RoomTemplateDatabase);
-            var room = database.CreateRoom2DInstance(roomId, root);
+            var room = database.CreateRoom2DInstance(roomId, layoutPack, root);
             var cellSize = room.CellSize;
             room.OnCellAreaEntered += (area, collision) => indexes.Add(new Vector2(area.Row, area.Column));
             room.OnCellAreaExited += (area, collision) => indexes.Remove(new Vector2(area.Row, area.Column));

--- a/tests/scripts/TestRoomNode3D.cs
+++ b/tests/scripts/TestRoomNode3D.cs
@@ -150,9 +150,9 @@ namespace MPewsey.ManiaMapGodot.Tests
             var state = new LayoutState(layout);
             var roomId = layout.Rooms.Keys.First();
             var roomState = state.RoomStates[roomId];
-            ManiaMapManager.Initialize(layout, state, new ManiaMapSettings());
+            var layoutPack = new LayoutPack(layout, state, new ManiaMapSettings());
 
-            var room = database.CreateRoom3DInstance(roomId, root);
+            var room = database.CreateRoom3DInstance(roomId, layoutPack, root);
             var roomFlags = room.FindChildren("*", nameof(RoomFlag3D), true, false);
             Assertions.AssertThat(roomFlags.Count).IsGreater(0);
             var roomFlag = roomFlags[0] as RoomFlag3D;
@@ -197,11 +197,11 @@ namespace MPewsey.ManiaMapGodot.Tests
             var state = new LayoutState(layout);
             var roomId = layout.Rooms.Keys.First();
             var roomState = state.RoomStates[roomId];
-            ManiaMapManager.Initialize(layout, state, settings);
+            var layoutPack = new LayoutPack(layout, state, settings);
 
             // Create room and hook up signals to detect the cells the test area is touching.
             var database = ResourceLoader.Load<RoomTemplateDatabase>(RoomTemplateDatabase);
-            var room = database.CreateRoom3DInstance(roomId, root);
+            var room = database.CreateRoom3DInstance(roomId, layoutPack, root);
             var cellSize = room.CellSize;
             room.OnCellAreaEntered += (area, collision) => indexes.Add(new Vector2(area.Row, area.Column));
             room.OnCellAreaExited += (area, collision) => indexes.Remove(new Vector2(area.Row, area.Column));

--- a/tests/scripts/drawing/TestLayoutTileMap.cs
+++ b/tests/scripts/drawing/TestLayoutTileMap.cs
@@ -22,8 +22,8 @@ namespace MPewsey.ManiaMapGodot.Drawing.Tests
             var layout = results.GetOutput<Layout>("Layout");
             var layoutState = new LayoutState(layout);
 
-            ManiaMapManager.Initialize(layout, layoutState);
-            map.DrawMap();
+            var layoutPack = new LayoutPack(layout, layoutState);
+            map.DrawMap(layoutPack);
         }
     }
 }

--- a/tests/scripts/drawing/TestLayoutTileMapBook.cs
+++ b/tests/scripts/drawing/TestLayoutTileMapBook.cs
@@ -22,8 +22,8 @@ namespace MPewsey.ManiaMapGodot.Drawing.Tests
             var layout = results.GetOutput<Layout>("Layout");
             var layoutState = new LayoutState(layout);
 
-            ManiaMapManager.Initialize(layout, layoutState);
-            map.DrawPages();
+            var layoutPack = new LayoutPack(layout, layoutState);
+            map.DrawPages(layoutPack);
         }
     }
 }


### PR DESCRIPTION
The `ManiaMapManager`'s function was to hold some cached calculated properties about the layout and provide shorthand initialization for rooms. However, this placed the unnecessary constraint that only one layout could be "active" within the `ManiaMapManager` singleton at a given time. This PR converts the `ManiaMapManager` singleton to a `LayoutPack` class, which performs the same calculated property caching and serves as a single object that can be passed to room instantiation methods.