### PR TITLE
Move common methods to LayoutPack

### DIFF
--- a/addons/mpewsey.maniamap/scripts/runtime/IDoorNodeExtensions.cs
+++ b/addons/mpewsey.maniamap/scripts/runtime/IDoorNodeExtensions.cs
@@ -22,18 +22,13 @@ namespace MPewsey.ManiaMapGodot
         /// </summary>
         public static DoorConnection FindDoorConnection(this IDoorNode door)
         {
+            if (!door.RoomNode.IsInitialized)
+                return null;
+
             var roomId = door.RoomNode.RoomLayout.Id;
-            var doorConnections = door.RoomNode.LayoutPack.GetDoorConnections(roomId);
             var position = new Vector2DInt(door.Row, door.Column);
             var direction = door.DoorDirection;
-
-            foreach (var connection in doorConnections)
-            {
-                if (connection.ContainsDoor(roomId, position, direction))
-                    return connection;
-            }
-
-            return null;
+            return door.RoomNode.LayoutPack.FindDoorConnection(roomId, position, direction);
         }
 
         /// <summary>

--- a/addons/mpewsey.maniamap/scripts/runtime/LayoutPack.cs
+++ b/addons/mpewsey.maniamap/scripts/runtime/LayoutPack.cs
@@ -1,4 +1,5 @@
 using Godot;
+using MPewsey.Common.Mathematics;
 using MPewsey.ManiaMap;
 using System;
 using System.Collections.Generic;
@@ -29,6 +30,16 @@ namespace MPewsey.ManiaMapGodot
         /// A dictionary of door connections by room ID.
         /// </summary>
         private Dictionary<Uid, List<DoorConnection>> RoomConnections { get; } = new Dictionary<Uid, List<DoorConnection>>();
+
+        /// <summary>
+        /// A dictionary of rooms by layer coordinate.
+        /// </summary>
+        private Dictionary<int, List<Room>> RoomsByLayer { get; } = new Dictionary<int, List<Room>>();
+
+        /// <summary>
+        /// A dictionary of door positions by room ID.
+        /// </summary>
+        private Dictionary<Uid, List<DoorPosition>> RoomDoors { get; } = new Dictionary<Uid, List<DoorPosition>>();
 
         /// <summary>
         /// Initializes a new layout pack.
@@ -62,6 +73,8 @@ namespace MPewsey.ManiaMapGodot
             LayoutState = state;
             Settings = settings;
             RoomConnections = layout.GetRoomConnections();
+            RoomsByLayer = layout.GetRoomsByLayer();
+            RoomDoors = layout.GetRoomDoors();
         }
 
         /// <summary>
@@ -74,6 +87,74 @@ namespace MPewsey.ManiaMapGodot
             if (RoomConnections.TryGetValue(id, out var connections))
                 return connections;
             return Array.Empty<DoorConnection>();
+        }
+
+        /// <summary>
+        /// Returns a list of rooms corresponding to the specified layer (z) coordinate.
+        /// If the layer does not exist, returns an empty list.
+        /// </summary>
+        /// <param name="z">The layer coordinate.</param>
+        public IReadOnlyList<Room> GetRoomsInLayer(int z)
+        {
+            if (RoomsByLayer.TryGetValue(z, out var rooms))
+                return rooms;
+            return Array.Empty<Room>();
+        }
+
+        /// <summary>
+        /// Returns a list of door positions for the specified room ID.
+        /// If the room ID does not exist, returns an empty list.
+        /// </summary>
+        /// <param name="id">The room ID.</param>
+        public IReadOnlyList<DoorPosition> GetRoomDoors(Uid id)
+        {
+            if (RoomDoors.TryGetValue(id, out var doors))
+                return doors;
+            return Array.Empty<DoorPosition>();
+        }
+
+        /// <summary>
+        /// Returns true if the door exists for the specified cell index and direction.
+        /// </summary>
+        /// <param name="id">The room ID.</param>
+        /// <param name="position">The cell index in the room.</param>
+        /// <param name="direction">The door direction.</param>
+        public bool DoorExists(Uid id, Vector2DInt position, DoorDirection direction)
+        {
+            foreach (var door in GetRoomDoors(id))
+            {
+                if (door.Matches(position, direction))
+                    return true;
+            }
+
+            return false;
+        }
+
+        /// <summary>
+        /// Returns an enumerable of unique layer (z) coordinates for the layout.
+        /// The coordinates are not in any particular order.
+        /// </summary>
+        public IEnumerable<int> GetLayerCoordinates()
+        {
+            return RoomsByLayer.Keys;
+        }
+
+        /// <summary>
+        /// Returns the door connection with the given room ID, position, and direction if it exists.
+        /// Returns null if the connection does not exist.
+        /// </summary>
+        /// <param name="id">The room ID.</param>
+        /// <param name="position">The cell position index.</param>
+        /// <param name="direction">The door direction.</param>
+        public DoorConnection FindDoorConnection(Uid id, Vector2DInt position, DoorDirection direction)
+        {
+            foreach (var connection in GetDoorConnections(id))
+            {
+                if (connection.ContainsDoor(id, position, direction))
+                    return connection;
+            }
+
+            return null;
         }
     }
 }

--- a/addons/mpewsey.maniamap/scripts/runtime/drawing/LayoutTileMap.cs
+++ b/addons/mpewsey.maniamap/scripts/runtime/drawing/LayoutTileMap.cs
@@ -20,13 +20,6 @@ namespace MPewsey.ManiaMapGodot.Drawing
         /// </summary>
         public int LayerCoordinate { get; private set; }
 
-        /// <inheritdoc/>
-        protected override void Initialize(Layout layout, LayoutState layoutState)
-        {
-            base.Initialize(layout, layoutState);
-            TileMap ??= CreateTileMap();
-        }
-
         /// <summary>
         /// Draws the map for the specified layer (z) coordinate.
         /// </summary>
@@ -34,7 +27,10 @@ namespace MPewsey.ManiaMapGodot.Drawing
         /// <param name="z">The layer coordinate. If null, the minimum layer coordinate in the layout will be used.</param>
         public void DrawMap(LayoutPack layoutPack, int? z = null)
         {
-            DrawMap(layoutPack.Layout, layoutPack.LayoutState, z);
+            LayoutPack = layoutPack;
+            LayerCoordinate = z ?? layoutPack.GetLayerCoordinates().Order().First();
+            TileMap ??= CreateTileMap();
+            SetTiles(TileMap, LayerCoordinate);
         }
 
         /// <summary>
@@ -45,9 +41,9 @@ namespace MPewsey.ManiaMapGodot.Drawing
         /// <param name="z">The layer coordinate. If null, the minimum layer coordinate in the layout will be used.</param>
         public void DrawMap(Layout layout, LayoutState layoutState = null, int? z = null)
         {
-            Initialize(layout, layoutState);
-            LayerCoordinate = z ?? RoomsByLayer.Keys.Order().First();
-            SetTiles(TileMap, LayerCoordinate);
+            layoutState ??= CreateFullyVisibleLayoutState(layout);
+            var layoutPack = new LayoutPack(layout, layoutState, new ManiaMapSettings());
+            DrawMap(layoutPack, z);
         }
     }
 }

--- a/addons/mpewsey.maniamap/scripts/runtime/drawing/LayoutTileMapBook.cs
+++ b/addons/mpewsey.maniamap/scripts/runtime/drawing/LayoutTileMapBook.cs
@@ -31,22 +31,21 @@ namespace MPewsey.ManiaMapGodot.Drawing
         /// </summary>
         public IReadOnlyList<int> GetPageLayerCoordinates() => PageLayerCoordinates;
 
-        /// <inheritdoc/>
-        protected override void Initialize(Layout layout, LayoutState layoutState)
-        {
-            base.Initialize(layout, layoutState);
-            PageLayerCoordinates = RoomsByLayer.Keys.ToList();
-            PageLayerCoordinates.Sort();
-            SizePages();
-        }
-
         /// <summary>
         /// Draws all layout layers onto tile maps.
         /// </summary>
         /// <param name="layoutPack">The layout pack.</param>
         public void DrawPages(LayoutPack layoutPack)
         {
-            DrawPages(layoutPack.Layout, layoutPack.LayoutState);
+            LayoutPack = layoutPack;
+            PageLayerCoordinates = layoutPack.GetLayerCoordinates().ToList();
+            PageLayerCoordinates.Sort();
+            SizePages();
+
+            for (int i = 0; i < Pages.Count; i++)
+            {
+                SetTiles(Pages[i], PageLayerCoordinates[i]);
+            }
         }
 
         /// <summary>
@@ -56,12 +55,9 @@ namespace MPewsey.ManiaMapGodot.Drawing
         /// <param name="layoutState">The layout state. If null, the full map will be drawn. Otherwise, the layout state cell visibilities will be applied.</param>
         public void DrawPages(Layout layout, LayoutState layoutState = null)
         {
-            Initialize(layout, layoutState);
-
-            for (int i = 0; i < Pages.Count; i++)
-            {
-                SetTiles(Pages[i], PageLayerCoordinates[i]);
-            }
+            layoutState ??= CreateFullyVisibleLayoutState(layout);
+            var layoutPack = new LayoutPack(layout, layoutState, new ManiaMapSettings());
+            DrawPages(layoutPack);
         }
 
         /// <summary>


### PR DESCRIPTION
* Move cached dictionaries and associated lookup methods from `LayoutTileMapBase` to `LayoutPack`.
* Move door connection lookup method from `IDoorExtensions` to `LayoutPack`.