### PR TITLE
Add fallback resource paths

### DIFF
--- a/addons/mpewsey.maniamap/ManiaMapPlugin.cs
+++ b/addons/mpewsey.maniamap/ManiaMapPlugin.cs
@@ -124,7 +124,7 @@ namespace MPewsey.ManiaMapGodot.Editor
 
         private void AddGraphEditorDock()
         {
-            var scene = ResourceLoader.Load<PackedScene>(ManiaMapResources.Scenes.LayoutGraphEditorScene);
+            var scene = ManiaMapResources.Scenes.LayoutGraphEditorScene.Load<PackedScene>();
             GraphEditor = scene.Instantiate<LayoutGraphEditor>();
             GraphEditorDockButton = AddControlToBottomPanel(GraphEditor, GraphEditorDockButtonName);
             GraphEditorDockButton.Visible = false;
@@ -155,7 +155,7 @@ namespace MPewsey.ManiaMapGodot.Editor
             var mainScreen2d = EditorInterface.Singleton.GetEditorMainScreen().GetChild(0);
             var hFlowContainers = mainScreen2d.FindChildren("*", nameof(HFlowContainer), true, false);
             var buttonContainer = (HFlowContainer)hFlowContainers[0];
-            var scene = ResourceLoader.Load<PackedScene>(ManiaMapResources.Scenes.RoomNode2DToolbarScene);
+            var scene = ManiaMapResources.Scenes.RoomNode2DToolbarScene.Load<PackedScene>();
             var toolbar = scene.Instantiate<RoomNode2DToolbar>();
             RoomNode2DToolbar = toolbar;
             buttonContainer.AddChild(toolbar);
@@ -167,7 +167,7 @@ namespace MPewsey.ManiaMapGodot.Editor
             var mainScreen3d = EditorInterface.Singleton.GetEditorMainScreen().GetChild(1);
             var hFlowContainers = mainScreen3d.FindChildren("*", nameof(HFlowContainer), true, false);
             var buttonContainer = (HFlowContainer)hFlowContainers[0];
-            var scene = ResourceLoader.Load<PackedScene>(ManiaMapResources.Scenes.RoomNode3DToolbarScene);
+            var scene = ManiaMapResources.Scenes.RoomNode3DToolbarScene.Load<PackedScene>();
             var toolbar = scene.Instantiate<RoomNode3DToolbar>();
             RoomNode3DToolbar = toolbar;
             buttonContainer.AddChild(toolbar);

--- a/addons/mpewsey.maniamap/plugin.cfg
+++ b/addons/mpewsey.maniamap/plugin.cfg
@@ -3,5 +3,5 @@
 name="ManiaMap.Godot"
 description="Procedural generation of metroidvania style maps for Godot .NET."
 author="Matt Pewsey"
-version="1.0.1"
+version="1.0.2"
 script="ManiaMapPlugin.cs"

--- a/addons/mpewsey.maniamap/scripts/runtime/ManiaMapResources.cs
+++ b/addons/mpewsey.maniamap/scripts/runtime/ManiaMapResources.cs
@@ -23,9 +23,9 @@ namespace MPewsey.ManiaMapGodot
         /// </summary>
         public static class Scenes
         {
-            public const string LayoutGraphEditorScene = "uid://ckyjrhwvcs6fi";
-            public const string RoomNode2DToolbarScene = "uid://ceij50wkmgvyi";
-            public const string RoomNode3DToolbarScene = "uid://b25t77npx7a3l";
+            public static SceneRef LayoutGraphEditorScene { get; } = new SceneRef("uid://ckyjrhwvcs6fi", "res://addons/mpewsey.maniamap/scenes/layout_graph_editor/layout_graph_editor.tscn");
+            public static SceneRef RoomNode2DToolbarScene { get; } = new SceneRef("uid://ceij50wkmgvyi", "res://addons/mpewsey.maniamap/scenes/room_node_2d_toolbar/room_node_2d_toolbar.tscn");
+            public static SceneRef RoomNode3DToolbarScene { get; } = new SceneRef("uid://b25t77npx7a3l", "res://addons/mpewsey.maniamap/scenes/room_node_3d_toolbar/room_node_3d_toolbar.tscn");
         }
 
         /// <summary>
@@ -33,7 +33,8 @@ namespace MPewsey.ManiaMapGodot
         /// </summary>
         public static class Materials
         {
-            public static Material AlbedoMaterial { get; } = ResourceLoader.Load<Material>("uid://ppa2shs6thgv");
+            public static SceneRef AlbedoMaterialPath { get; } = new SceneRef("uid://ppa2shs6thgv", "res://addons/mpewsey.maniamap/materials/albedo_material.tres");
+            public static Material AlbedoMaterial { get; } = AlbedoMaterialPath.Load<Material>();
         }
 
         /// <summary>

--- a/addons/mpewsey.maniamap/scripts/runtime/ManiaMapResources.cs
+++ b/addons/mpewsey.maniamap/scripts/runtime/ManiaMapResources.cs
@@ -23,9 +23,9 @@ namespace MPewsey.ManiaMapGodot
         /// </summary>
         public static class Scenes
         {
-            public static SceneRef LayoutGraphEditorScene { get; } = new SceneRef("uid://ckyjrhwvcs6fi", "res://addons/mpewsey.maniamap/scenes/layout_graph_editor/layout_graph_editor.tscn");
-            public static SceneRef RoomNode2DToolbarScene { get; } = new SceneRef("uid://ceij50wkmgvyi", "res://addons/mpewsey.maniamap/scenes/room_node_2d_toolbar/room_node_2d_toolbar.tscn");
-            public static SceneRef RoomNode3DToolbarScene { get; } = new SceneRef("uid://b25t77npx7a3l", "res://addons/mpewsey.maniamap/scenes/room_node_3d_toolbar/room_node_3d_toolbar.tscn");
+            public static PathRef LayoutGraphEditorScene { get; } = new PathRef("uid://ckyjrhwvcs6fi", "res://addons/mpewsey.maniamap/scenes/layout_graph_editor/layout_graph_editor.tscn");
+            public static PathRef RoomNode2DToolbarScene { get; } = new PathRef("uid://ceij50wkmgvyi", "res://addons/mpewsey.maniamap/scenes/room_node_2d_toolbar/room_node_2d_toolbar.tscn");
+            public static PathRef RoomNode3DToolbarScene { get; } = new PathRef("uid://b25t77npx7a3l", "res://addons/mpewsey.maniamap/scenes/room_node_3d_toolbar/room_node_3d_toolbar.tscn");
         }
 
         /// <summary>
@@ -33,7 +33,7 @@ namespace MPewsey.ManiaMapGodot
         /// </summary>
         public static class Materials
         {
-            public static SceneRef AlbedoMaterialPath { get; } = new SceneRef("uid://ppa2shs6thgv", "res://addons/mpewsey.maniamap/materials/albedo_material.tres");
+            public static PathRef AlbedoMaterialPath { get; } = new PathRef("uid://ppa2shs6thgv", "res://addons/mpewsey.maniamap/materials/albedo_material.tres");
             public static Material AlbedoMaterial { get; } = AlbedoMaterialPath.Load<Material>();
         }
 

--- a/addons/mpewsey.maniamap/scripts/runtime/PathRef.cs
+++ b/addons/mpewsey.maniamap/scripts/runtime/PathRef.cs
@@ -2,12 +2,12 @@ using Godot;
 
 namespace MPewsey.ManiaMapGodot
 {
-    public readonly struct SceneRef
+    public readonly struct PathRef
     {
         public string UidPath { get; }
         public string ResPath { get; }
 
-        public SceneRef(string uidPath, string resPath)
+        public PathRef(string uidPath, string resPath)
         {
             UidPath = uidPath;
             ResPath = resPath;
@@ -15,7 +15,7 @@ namespace MPewsey.ManiaMapGodot
 
         public string GetLoadPath()
         {
-            return ResourceLoader.Exists(UidPath) ? UidPath : ResPath;
+            return ResourceLoader.Exists(ResPath) ? ResPath : UidPath;
         }
 
         public T Load<T>() where T : class

--- a/addons/mpewsey.maniamap/scripts/runtime/SceneRef.cs
+++ b/addons/mpewsey.maniamap/scripts/runtime/SceneRef.cs
@@ -1,0 +1,26 @@
+using Godot;
+
+namespace MPewsey.ManiaMapGodot
+{
+    public readonly struct SceneRef
+    {
+        public string UidPath { get; }
+        public string ResPath { get; }
+
+        public SceneRef(string uidPath, string resPath)
+        {
+            UidPath = uidPath;
+            ResPath = resPath;
+        }
+
+        public string GetLoadPath()
+        {
+            return ResourceLoader.Exists(UidPath) ? UidPath : ResPath;
+        }
+
+        public T Load<T>() where T : class
+        {
+            return ResourceLoader.Load<T>(GetLoadPath());
+        }
+    }
+}


### PR DESCRIPTION
Add fallback resource paths to resolve issues where uid:// paths were not available at load time in Godot 4.3.