### PR TITLE
Add quiet signal disconnection

### DIFF
--- a/addons/mpewsey.maniamap/scripts/editor/RoomNode2DToolbar.cs
+++ b/addons/mpewsey.maniamap/scripts/editor/RoomNode2DToolbar.cs
@@ -1,5 +1,6 @@
 #if TOOLS
 using Godot;
+using MPewsey.ManiaMapGodot.Extensions;
 
 namespace MPewsey.ManiaMapGodot.Editor
 {
@@ -49,7 +50,7 @@ namespace MPewsey.ManiaMapGodot.Editor
         private void OnRoomExitedTree()
         {
             if (IsInstanceValid(Room))
-                Room.TreeExited -= OnRoomExitedTree;
+                Room.QuietDisconnect(Node.SignalName.TreeExited, OnRoomExitedTree);
 
             Room = null;
         }

--- a/addons/mpewsey.maniamap/scripts/editor/RoomNode3DToolbar.cs
+++ b/addons/mpewsey.maniamap/scripts/editor/RoomNode3DToolbar.cs
@@ -1,5 +1,6 @@
 #if TOOLS
 using Godot;
+using MPewsey.ManiaMapGodot.Extensions;
 
 namespace MPewsey.ManiaMapGodot.Editor
 {
@@ -86,7 +87,7 @@ namespace MPewsey.ManiaMapGodot.Editor
         private void OnRoomExitedTree()
         {
             if (IsInstanceValid(Room))
-                Room.TreeExited -= OnRoomExitedTree;
+                Room.QuietDisconnect(Node.SignalName.TreeExited, OnRoomExitedTree);
 
             Room = null;
         }

--- a/addons/mpewsey.maniamap/scripts/editor/graphs/LayoutGraphEditor.cs
+++ b/addons/mpewsey.maniamap/scripts/editor/graphs/LayoutGraphEditor.cs
@@ -1,6 +1,7 @@
 #if TOOLS
 using Godot;
 using MPewsey.ManiaMapGodot.Editor;
+using MPewsey.ManiaMapGodot.Extensions;
 using System.Collections.Generic;
 using System.Linq;
 
@@ -293,7 +294,7 @@ namespace MPewsey.ManiaMapGodot.Graphs.Editor
             if (GraphResource != null)
             {
                 GraphResource.SaveIfDirty();
-                GraphResource.Changed -= OnGraphResourceChanged;
+                GraphResource.QuietDisconnect(Resource.SignalName.Changed, OnGraphResourceChanged);
                 GraphResource.UnregisterOnSubresourceChangedSignals();
                 GraphResource = null;
             }

--- a/addons/mpewsey.maniamap/scripts/runtime/extensions/GodotObjectExtensions.cs
+++ b/addons/mpewsey.maniamap/scripts/runtime/extensions/GodotObjectExtensions.cs
@@ -1,0 +1,24 @@
+using Godot;
+using System;
+
+namespace MPewsey.ManiaMapGodot.Extensions
+{
+    public static class GodotObjectExtensions
+    {
+        public static void QuietDisconnect(this GodotObject obj, StringName signalName, Action action)
+        {
+            var callable = Callable.From(action);
+
+            if (obj.IsConnected(signalName, callable))
+                obj.Disconnect(signalName, callable);
+        }
+
+        public static void QuietDisconnect<T0>(this GodotObject obj, StringName signalName, Action<T0> action)
+        {
+            var callable = Callable.From(action);
+
+            if (obj.IsConnected(signalName, callable))
+                obj.Disconnect(signalName, callable);
+        }
+    }
+}

--- a/addons/mpewsey.maniamap/scripts/runtime/graphs/LayoutGraphResource.cs
+++ b/addons/mpewsey.maniamap/scripts/runtime/graphs/LayoutGraphResource.cs
@@ -1,5 +1,6 @@
 using Godot;
 using MPewsey.ManiaMap.Graphs;
+using MPewsey.ManiaMapGodot.Extensions;
 using System;
 using System.Collections.Generic;
 
@@ -78,12 +79,12 @@ namespace MPewsey.ManiaMapGodot.Graphs
         {
             foreach (var node in Nodes.Values)
             {
-                node.Changed -= OnSubresourceChanged;
+                node.QuietDisconnect(Resource.SignalName.Changed, OnSubresourceChanged);
             }
 
             foreach (var edge in Edges.Values)
             {
-                edge.Changed -= OnSubresourceChanged;
+                edge.QuietDisconnect(Resource.SignalName.Changed, OnSubresourceChanged);
             }
         }
 


### PR DESCRIPTION
Add check that a signal connection exists before removing it to prevent warnings from popping up in the editor.